### PR TITLE
Removing reference to a non-existing file

### DIFF
--- a/PimcoreHrefTypeaheadBundle.php
+++ b/PimcoreHrefTypeaheadBundle.php
@@ -11,8 +11,7 @@ class PimcoreHrefTypeaheadBundle extends AbstractPimcoreBundle
     {
         return [
             '/bundles/pimcorehreftypeahead/js/pimcore/object/tags/hrefTypeahead.js',
-            '/bundles/pimcorehreftypeahead/js/pimcore/object/classes/data/hrefTypeahead.js',
-            '/bundles/pimcorehreftypeahead/js/HrefObject.js'
+            '/bundles/pimcorehreftypeahead/js/pimcore/object/classes/data/hrefTypeahead.js'
         ];
     }
 


### PR DESCRIPTION
The file: **'/bundles/pimcorehreftypeahead/js/HrefObject.js'** does not exists. Removing it from the getJsPaths method.