### PR TITLE
adding event "change" - pimcore 5

### DIFF
--- a/Resources/public/js/pimcore/object/tags/hrefTypeahead.js
+++ b/Resources/public/js/pimcore/object/tags/hrefTypeahead.js
@@ -149,6 +149,11 @@ pimcore.object.tags.hrefTypeahead = Class.create(pimcore.object.tags.abstract, {
                 this.data.type    = newRecord.data.type;
                 this.data.subtype = newRecord.data.subtype;
             }
+            
+            if (this.dataChanged && this.fieldConfig.listeners != undefined && {}.toString.call(this.fieldConfig.listeners.change) === '[object Function]'){
+                this.fieldConfig.listeners.change(combobox, newValue, oldValue);
+            }
+            
         }.bind(this));
 
         var items = [this.component, {


### PR DESCRIPTION
on the definition of the element you can use:
```javascript
{listeners: {
                        'change': function(field){
                            var f = Ext.getCmp(field.name + '_override');
                            f.setValue(true);
                        }
                    };
}
```