### PR TITLE
Compatibility with new Pimcore versions

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -2,18 +2,18 @@
 
 namespace PimcoreHrefTypeaheadBundle\Controller;
 
-use Pimcore\Bundle\AdminBundle\Controller\AdminController;
-use Pimcore\Tool;
+use PimcoreHrefTypeaheadBundle\Model\DataObject\Data\HrefTypeahead;
 use PimcoreHrefTypeaheadBundle\Service\SearchBuilder;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-
+use Pimcore\Bundle\AdminBundle\Controller\AdminController;
+use Pimcore\Bundle\AdminBundle\Helper\QueryParams;
 use Pimcore\Logger;
 use Pimcore\Model\Element;
 use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\DataObject;
-use PimcoreHrefTypeaheadBundle\Model\DataObject\Data\HrefTypeahead;
+use Pimcore\Tool;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class DefaultController
@@ -76,7 +76,7 @@ class DefaultController extends AdminController
         }
         $filter = $request->get('filter') ? \Zend_Json::decode($request->get('filter')) : null;
         $considerChildTags = $request->get('considerChildTags') === 'true';
-        $sortingSettings = \Pimcore\Admin\Helper\QueryParams::extractSortingSettings($request->request->all());
+        $sortingSettings = QueryParams::extractSortingSettings($request->request->all());
         $searchService = $searchBuilder
             ->withUser($this->getAdminUser())
             ->withTypes(['object'])

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Allows typeahead functionality in href",
   "type": "pimcore-bundle",
   "require": {
-    "pimcore/core-version": ">=5.4.0"
+    "pimcore/core-version": ">=5.1.0"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Allows typeahead functionality in href",
   "type": "pimcore-bundle",
   "require": {
-    "pimcore/core-version": ">=5.1.0"
+    "pimcore/core-version": ">=5.4.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no

In Pimcore ^5.0 || ^6.0 helper is QueryParams helper is located under different namespace:
`Pimcore\Bundle\AdminBundle\Helper`

Tested on Pimcore `6.2.1` but in all 5,6 versions helper is located under the same namespace:
https://github.com/pimcore/pimcore/blob/v5.0.0/pimcore/lib/Pimcore/Bundle/AdminBundle/Helper/QueryParams.php
 