### PR TITLE
Pimcore 6 / Symfony 4 compatibility

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -12,9 +12,9 @@ use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Helper\PathFormatterResolver;
 use Pimcore\Tool;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class DefaultController
@@ -25,6 +25,8 @@ use Symfony\Component\HttpFoundation\Response;
 class DefaultController extends AdminController
 {
     /**
+     * @param Request $request
+     * @param SearchBuilder $searchBuilder
      * @Route("/find")
      */
     public function findAction(Request $request, SearchBuilder $searchBuilder)
@@ -135,6 +137,7 @@ class DefaultController extends AdminController
             'nicePathKey' => Element\Service::getType($element) . '_' . $element->getId(),
         ];
     }
+
     /**
      * @param DataObject\ClassDefinition\Data $fd
      * @param AbstractElement $element

--- a/Resources/public/css/style.css
+++ b/Resources/public/css/style.css
@@ -1,3 +1,3 @@
 .pimcore_icon_hrefTypeahead{
-    background: url(/pimcore/static6/img/flat-color-icons/object.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/object.svg) center center no-repeat !important;
 }

--- a/Resources/translations/admin.en.csv
+++ b/Resources/translations/admin.en.csv
@@ -1,2 +1,0 @@
-hrefTypeahead,"Href typeahead"
-show_trigger,"Show dropdown trigger"

--- a/Resources/translations/admin.en.yml
+++ b/Resources/translations/admin.en.yml
@@ -1,0 +1,2 @@
+hrefTypeahead: Href typeahead
+show_trigger: Show dropdown trigger

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Allows typeahead functionality in href",
   "type": "pimcore-bundle",
   "require": {
-    "pimcore/pimcore": ">=5.8.0"
+    "pimcore/pimcore": "^5.8 || ^6.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Hi!

In PR added fixes for Pimcore 6 (and they are actual for Pimcore 5.8) and Symfony 4:
- Replaced Sensio bundle routing component to native Symfony
- Make translations in yml (as native Symfony way)
- Fixed icon path
- small PHPdoc improvements

Please review,
Thnx! 