### PR TITLE
Pimcore 10 / Symfony 5 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('pimcore_href_typeahead');
+        $treeBuilder = new TreeBuilder('pimcore_href_typeahead');
+        $rootNode = $treeBuilder->getRootNode();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/Event/HreftypeaheadSearchEvent.php
+++ b/Event/HreftypeaheadSearchEvent.php
@@ -15,9 +15,9 @@
 namespace PimcoreHrefTypeaheadBundle\Event;
 
 use Pimcore\Model\DataObject;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
-class HreftypeaheadSearchEvent extends Event
+class HreftypeaheadSearchEvent extends GenericEvent
 {
     const SEARCH_EVENT = 'hreftypeahead.search';
 

--- a/Model/DataObject/ClassDefinition/Data/HrefTypeahead.php
+++ b/Model/DataObject/ClassDefinition/Data/HrefTypeahead.php
@@ -6,8 +6,9 @@ use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element;
+use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation;
 
-class HrefTypeahead extends Model\DataObject\ClassDefinition\Data\Href
+class HrefTypeahead extends ManyToOneRelation
 {
     /**
      * Static type of this element

--- a/Service/SearchService.php
+++ b/Service/SearchService.php
@@ -214,7 +214,7 @@ class SearchService
         //filtering for tags
         $conditionParts = $this->appendTagConditions($conditionParts);
 
-        $this->dispatcher->dispatch(HreftypeaheadSearchEvent::SEARCH_EVENT, new HreftypeaheadSearchEvent($this->sourceObject, $conditionParts));
+        $this->dispatcher->dispatch(new HreftypeaheadSearchEvent($this->sourceObject, $conditionParts), HreftypeaheadSearchEvent::SEARCH_EVENT);
 
         if (count($conditionParts) > 0) {
             $condition = implode(' AND ', $conditionParts);
@@ -269,7 +269,8 @@ class SearchService
 
                 return $forbiddenConditions;
             } else {
-                $forbiddenAssetPaths = Element\Service::findForbiddenPaths('asset', $this->user);
+                $assetPaths = Element\Service::findForbiddenPaths('asset', $this->user);
+                $forbiddenAssetPaths = $assetPaths['forbidden'];
                 if (count($forbiddenAssetPaths) > 0) {
                     /** @noinspection CallableInLoopTerminationConditionInspection */
                     for ($i = 0; $i < count($forbiddenAssetPaths); $i++) {
@@ -300,7 +301,8 @@ class SearchService
 
                 return $forbiddenConditions;
             } else {
-                $forbiddenDocumentPaths = Element\Service::findForbiddenPaths('document', $this->user);
+                $documentPaths = Element\Service::findForbiddenPaths('document', $this->user);
+                $forbiddenDocumentPaths = $documentPaths['forbidden'];
                 if (count($forbiddenDocumentPaths) > 0) {
                     /** @noinspection CallableInLoopTerminationConditionInspection */
                     for ($i = 0; $i < count($forbiddenDocumentPaths); $i++) {
@@ -331,7 +333,8 @@ class SearchService
 
                 return $forbiddenConditions;
             } else {
-                $forbiddenObjectPaths = Element\Service::findForbiddenPaths('object', $this->user);
+                $objectPaths = Element\Service::findForbiddenPaths('object', $this->user);
+                $forbiddenObjectPaths = $objectPaths['forbidden'];
                 if (count($forbiddenObjectPaths) > 0) {
                     /** @noinspection CallableInLoopTerminationConditionInspection */
                     for ($i = 0; $i < count($forbiddenObjectPaths); $i++) {


### PR DESCRIPTION
Hello!

PR includes the follow compatibility improvements for Pimcore 10 and Symfony 5.

- Extend ManyToOneRelation instead of Href since Href was removed.
- Changed namespaces.
- Element\Service::findForbiddenPaths will now return both forbidden and allowed paths, so relevant functions were updated to maintain compatibility.